### PR TITLE
Provide else statement defining g:is_hlsearch in both cases

### DIFF
--- a/plugin/readability.vim
+++ b/plugin/readability.vim
@@ -14,6 +14,8 @@ endif
 
 if &hls
   let g:is_hlsearch = 1
+else
+  let g:is_hlsearch = 0
 endif
 
 let g:read_loaded = 1


### PR DESCRIPTION
This fixes the following error on startup:
Error detected while processing function ReadGradeEnable:
line    2:
E121: Undefined variable: g:is_hlsearch
line   12:
E121: Undefined variable: g:is_hlsearch